### PR TITLE
Changed to Team as owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @VerHext @Lapotor @GamerBoomTV
+*   @Support-pp/developer @Support-pp/reviewer


### PR DESCRIPTION
This change edits the Codeowners from @VerHext @Lapotor @GamerBoomTV to @Support-pp/reviewer and @Support-pp/developer.